### PR TITLE
Add cache for blockchain event calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ allOpen {
 }
 
 group = "com.ampnet"
-version = "0.4.1"
+version = "0.4.2"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 configurations {

--- a/src/main/kotlin/com/ampnet/reportserviceeth/blockchain/BlockchainEventServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/reportserviceeth/blockchain/BlockchainEventServiceImpl.kt
@@ -22,6 +22,7 @@ import org.web3j.protocol.core.methods.response.Log
 import org.web3j.protocol.core.methods.response.TransactionReceipt
 import org.web3j.tx.gas.DefaultGasProvider
 import java.math.BigInteger
+import java.util.concurrent.ConcurrentHashMap
 
 private val logger = KotlinLogging.logger {}
 
@@ -31,8 +32,8 @@ class BlockchainEventServiceImpl(
 ) : BlockchainEventService {
 
     private data class CacheKey(val address: String, val chainId: Long)
-    private val assetCache: MutableMap<CacheKey, IAssetCommon.AssetCommonState> = mutableMapOf()
-    private val stableCoinPrecisionCache: MutableMap<CacheKey, BigInteger> = mutableMapOf()
+    private val assetCache: MutableMap<CacheKey, IAssetCommon.AssetCommonState> = ConcurrentHashMap()
+    private val stableCoinPrecisionCache: MutableMap<CacheKey, BigInteger> = ConcurrentHashMap()
 
     @Throws(InternalException::class)
     override fun getAllEvents(startBlockNumber: Long, endBlockNumber: Long, chainId: Long): List<Event> {

--- a/src/main/kotlin/com/ampnet/reportserviceeth/blockchain/properties/ChainPropertiesHandler.kt
+++ b/src/main/kotlin/com/ampnet/reportserviceeth/blockchain/properties/ChainPropertiesHandler.kt
@@ -48,7 +48,7 @@ class ChainPropertiesHandler(private val applicationProperties: ApplicationPrope
         )
         val web3j = Web3j.build(HttpService(getChainRpcUrl(chain)))
         return ChainPropertiesWithServices(
-            web3j, ReadonlyTransactionManager(web3j, chainProperties.callerAddress), chainProperties
+            web3j, ReadonlyTransactionManager(web3j, chainProperties.callerAddress), chainProperties, chain.id
         )
     }
 

--- a/src/main/kotlin/com/ampnet/reportserviceeth/blockchain/properties/ChainPropertiesWithServices.kt
+++ b/src/main/kotlin/com/ampnet/reportserviceeth/blockchain/properties/ChainPropertiesWithServices.kt
@@ -7,5 +7,6 @@ import org.web3j.tx.TransactionManager
 data class ChainPropertiesWithServices(
     val web3j: Web3j,
     val transactionManager: TransactionManager,
-    val chain: ChainProperties
+    val chain: ChainProperties,
+    val chainId: Long
 )


### PR DESCRIPTION
Repetitive data like stablecoin precision and issuer is cached using simple map